### PR TITLE
Fix decode body response

### DIFF
--- a/src/Endpoints/BaseEndpoint.php
+++ b/src/Endpoints/BaseEndpoint.php
@@ -56,32 +56,13 @@ abstract class BaseEndpoint
         }
 
         if (collect($response->getHeader('Content-Type'))->first() !== 'application/json') {
-            return $response->getBody()->getContents();
+            return $body;
         }
 
         $object = @json_decode($body);
         if (json_last_error() != JSON_ERROR_NONE) {
             throw new SmtpeterException("Unable to decode smtpeter response: '{$body}'.");
         }
-
-//            $error = collect(collect($object->errors)->first());
-//
-//            $messageBag = collect('Error executing API call');
-//
-//            if ($error->has('code')) {
-//                $messageBag->push('('.$error->get('code').')');
-//            }
-//
-//            if ($error->has('message')) {
-//                $messageBag->push(': '.$error->get('message'));
-//            }
-//
-//            if ($error->has('human')) {
-//                $messageBag->push(': '.collect($error->get('human'))->first());
-//            }
-//
-//            throw new MyParcelException($messageBag->implode(' '), $response->getStatusCode());
-//        }
 
         return $object;
     }

--- a/src/Endpoints/Templates.php
+++ b/src/Endpoints/Templates.php
@@ -1,12 +1,12 @@
 <?php
 namespace Avido\Smtpeter\Endpoints;
 
+use Avido\Smtpeter\Exceptions\SmtpeterException;
 use Avido\Smtpeter\Resources\Template as TemplateResource;
 use Illuminate\Support\Collection;
 
 class Templates extends BaseEndpoint
 {
-
     /**
      * List all templates
      * @param int $start
@@ -20,6 +20,16 @@ class Templates extends BaseEndpoint
             'GET',
             '/templates' . $this->limit($start, $limit)
         );
+
+        // smtpeter returns wrong response header (text/html instead of application/json)
+        // decode body first
+        // as we don't know when smtpeter will fix this, we'll test for valid object first
+        if (!is_array($response)) {
+            $response = @json_decode($response);
+            if (json_last_error() != JSON_ERROR_NONE) {
+                throw new SmtpeterException("Unable to decode smtpeter response: '{$response}'.");
+            }
+        }
 
         $collection = new Collection();
 


### PR DESCRIPTION
## Changes
- Smtpeter returns wrong Content Type for /templates, therefore decoding fails.\
Validate if response was decoded
...

## References to Issues/Tasks

...


## Soort wijziging

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] Check-style
- [ ] Lint tested
- [ ] Unit tests added to cover changes
- [ ] All new and existing tests passed.
- [ ] Documentation update required & completed.
- [ ] Composer update required


## Optional comments

---
